### PR TITLE
[build] Add NPM version scripts

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## v0.0.1
+
+- Coming soon.

--- a/package.json
+++ b/package.json
@@ -13,5 +13,11 @@
   "homepage": "https://github.com/wikimedia/mw-vue-components",
   "repository": "github:wikimedia/mw-vue-components",
   "bugs": "https://phabricator.wikimedia.org/tag/vue.js",
-  "license": "GPL-2.0+"
+  "license": "GPL-2.0+",
+  "scripts": {
+    "preversion": "[ -z \"$(git status -z)\" ]",
+    "version": "npm t",
+    "postversion": "npm publish",
+    "prepublishOnly": "git push origin \"$(git rev-parse --abbrev-ref @)\" \"$(git tag --points-at @)\""
+  }
 }

--- a/readme.md
+++ b/readme.md
@@ -14,13 +14,21 @@ Vue.js user interface component library prototype for MediaWiki's Vector skin.
 
 - [Table of contents](#table-of-contents)
 - [Usage](#usage)
+- [Version history](#version-history)
 - [Development](#development)
   - [Quick start](#quick-start)
   - [NPM scripts](#npm-scripts)
+  - [Versioning](#versioning)
+- [Library design goals](#library-design-goals)
 
 <!-- /code_chunk_output -->
 
 ## Usage
+
+## Version history
+
+This library is [semantically versioned](https://semver.org). See the [changelog](changelog.md) for
+release notes.
 
 ## Development
 
@@ -33,6 +41,9 @@ npm i
 ### NPM scripts
 
 - `install` / `i`: install project dependencies. 
+- `version`: increment the version and publish a new release. See [versioning](#versioning).
+
+Undocumented scripts are considered internal utilities and not expressly supported workflows.
 
 <details markdown>
 <summary>
@@ -58,3 +69,87 @@ npm install
 # All dependencies are now available. Execute any project scripts as wanted.
 ```
 </details>
+
+### Versioning
+
+To publish a new release:
+
+1. Update the [changelog](changelog.md) with release notes.
+2. Commit the changelog.
+3. Execute `npm version <patch|minor|major>`.
+
+<details markdown>
+<summary>Expand for example…</summary>
+
+```bash
+# Review the changes since the last release. For example,
+# `git log "$(git describe --tags --abbrev=0)..@" --oneline`.
+
+# Document a new feature and a couple bug fixes since the last release. (Emacs can also be used to
+# edit the changelog.)
+vim changelog.md
+
+# Stage the changelog.
+git add changelog.md
+
+# Commit the changelog.
+git commit -m '[docs][changelog] prepare release notes'
+
+# Attempt a complete release.
+npm version minor
+```
+</details>
+
+<details markdown>
+<summary>
+The NPM scripts are configured to help ensure that only tested artifacts are published on Git and
+npmjs.com. Expand for details…
+</summary>
+
+By executing `npm version`, the following scripts are invoked in this order:
+1. `preversion`: test that the workspace contains no uncommitted changes.
+2. **`version`**: increment the version, clean, build, and test the candidate, commit, and tag the
+	change.
+3. `postversion`: call `publish`.
+4. `prepublishOnly`: push the Git tag to the remote.
+5. **`publish`**: push the artifacts to npmjs.com as per usual.
+
+In detail, `version` is a built-in NPM script that increases the package.json's `version` property
+(`patch`, `minor`, or `major`) as specified, commits the result to version control, and adds a Git
+tag. Prior to committing the version bump, clean, build, and test the candidate artifact.  See
+`npm help version` for further details.
+
+The `preversion` NPM script, which runs prior to `version`, is defined to test that Git's version
+control state is clean before that happens. No uncommitted changes are allowed! For example, imagine
+if a superfluous file containing a password was unintentionally in the workspace and published to
+npmjs.com.
+
+The `postversion` NPM script, which runs after `version`, simply enforces that the `publish` NPM
+script is called.
+
+Before `publish` is executed, `prepublishOnly` pushes the current commit and tag to the Git remote.
+If the push or publish fail due to connectivity, you should probably call `npm publish` directly
+which will re-push the tag and archive as needed.
+
+Finally, the `publish` script is executed which releases the raw files built into the wild at the
+[npm registry](https://www.npmjs.com). See `npm help publish` for further details.
+
+The intended result is:
+- Uncommitted changes (both modifications and untracked files) are forbidden.
+- Only clean and tested packages are published.
+- Git tags are available for all releases.
+- Git tags pushed and NPM artifacts publishes are always in sync.
+
+See also:
+- [NPM scripts](https://docs.npmjs.com/misc/scripts)
+- [NPM version](https://docs.npmjs.com/cli/version)
+</details>
+
+## Library design goals
+
+- Deploy search to all test wikis before August 31, 2020: frwiktionary, hewiki, ptwikiversity,
+	frwiki, euwiki, fawiki.
+- Relevant, modern, efficient, iterative contributor workflows.
+- Delightful user experiences shareable as an NPM package and reusable everywhere with and without
+	MediaWiki.
+- [Semantically versioned](https://semver.org).


### PR DESCRIPTION
This commit makes preparations for future releases:

- A few small but useful NPM scripts are added to automate and validate
  the release process.
- Documentation is provided to describe the process.
- A skeletal changelog is made. This is a reminder that the repo is
  semantically versioned and published, and that releases must be
  documented.