### PR TITLE
[build] rename to Wikimedia Vue UI

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@wikimedia/mw-vue-components",
+  "name": "@wikimedia/wvui",
   "author": "Wikimedia",
   "description": "Vue.js user interface components for Wikipedia, MediaWiki, and beyond.",
   "version": "0.0.0",
@@ -10,8 +10,8 @@
     "MediaWiki",
     "Wikimedia"
   ],
-  "homepage": "https://github.com/wikimedia/mw-vue-components",
-  "repository": "github:wikimedia/mw-vue-components",
+  "homepage": "https://github.com/wikimedia/wvui",
+  "repository": "github:wikimedia/wvui",
   "bugs": "https://phabricator.wikimedia.org/tag/vue.js",
   "license": "GPL-2.0+",
   "scripts": {

--- a/readme.md
+++ b/readme.md
@@ -1,4 +1,4 @@
-# 🧩 @wikimedia/mw-vue-components
+# 🧩 Wikimedia Vue UI
 
 Vue.js user interface component library prototype for MediaWiki's Vector skin.
 
@@ -92,15 +92,15 @@ The steps are:
 4. Note the component library's directory. For example, `libraryDir="$PWD"`.
 5. Enter your integration project's directory. For example, if you are integrating the library into
 	Vector, the command might be `cd ~/dev/mediawiki/skins/Vector`. This location should contain a
-	package.json with a `@wikimedia/mw-vue-components` dependency (either `dependency`,
+	package.json with a `@wikimedia/wvui` dependency (either `dependency`,
 	`devDependency`, or `peerDependency`).
 6. Symbolically link the development library into the integration project via
 	`npm link "$libraryDir"` where `$libraryDir` is the location of the component library. This swaps
 	the published production library for a link to your local development copy.
 7. Verify the link is correct by seeing where that it resolves to component library's location. For
-	example, `readlink -m node_modules/@wikimedia/mw-vue-components` should match `$libraryDir`.
+	example, `readlink -m node_modules/@wikimedia/wvui` should match `$libraryDir`.
 8. Perform all development and iteration wanted in the component library and integration project.
-9. Unlink the development library via `npm unlink @wikimedia/mw-vue-components`. This deletes the
+9. Unlink the development library via `npm unlink @wikimedia/wvui`. This deletes the
 	_symlink_ to your development copy of the component library.
 
 The above process seems a little clumsy because it is initially. However, it's quite practical and


### PR DESCRIPTION
This change represents a good faith edit to apply the renaming guidance
decided in T253357:

- Rename readme title from "@wikimedia/mw-vue-components" to the exact
  name voted on: "Wikimedia Vue UI". The package name could also be used
  if that's preferred.

- Rename package and repo references to the ambiguous `@wikimedia/wvui`.
  Package and repo names cannot contain spaces as far as I know and WVUI
  was mentioned in the official rubric as an abbreviation.

Please also note:

- Repository naming itself will happen only after this patch has been
  merged since there's no review process for that.

- Gerrit vs GitHub changes are out of scope.

- No other changes please. There are ~30 people involved just for
  naming.

Bug: T253357